### PR TITLE
Display cursor when a USB mouse is connected

### DIFF
--- a/sparse/etc/dconf/db/vendor.d/compositor-cursor.txt
+++ b/sparse/etc/dconf/db/vendor.d/compositor-cursor.txt
@@ -1,0 +1,2 @@
+[desktop/sailfish/compositor]
+display_cursor=true

--- a/sparse/var/lib/environment/compositor/droid-hal-device.conf
+++ b/sparse/var/lib/environment/compositor/droid-hal-device.conf
@@ -3,4 +3,4 @@ EGL_PLATFORM=hwcomposer
 QT_QPA_PLATFORM=hwcomposer
 QT_QPA_EGLFS_PHYSICAL_WIDTH=65
 QT_QPA_EGLFS_PHYSICAL_HEIGHT=130
-LIPSTICK_OPTIONS="-plugin evdevtouch -plugin evdevkeyboard"
+LIPSTICK_OPTIONS="-plugin evdevtouch -plugin evdevkeyboard -plugin evdevmouse"


### PR DESCRIPTION
This works only in portrait. @elros34's [qt5 plugin](https://github.com/elros34/qtbase/releases/tag/0.0.2) would be necessary to rotate mouse coordinates dynamically, but I haven't managed to install it. I know it works on my Pro1, but (i) this is a Pro1 port, and (2) mine is still running SFOS 3.3.

Please make sure that I didn't do shenanigans with this PR, as my fork was behind when I committed this, and I'm concerned that my merge commit to catch up with upstream now shows in the PR.