### PR TITLE
Remove check for bengal and hint that screen will blank

### DIFF
--- a/sparse/boot/flash.sh
+++ b/sparse/boot/flash.sh
@@ -15,18 +15,17 @@ $(tput setaf 2)fastboot found, proceeding.$(tput sgr0)"
 fi
 
 echo "
-$(tput setaf 2)Be aware, the flashing process might take up to 10 minutes.$(tput sgr0)
+$(tput setaf 220)Be aware, the flashing process might take up to 10 minutes.
+The screen is expected to go black. This is fine, flashing continues.$(tput sgr0)
+
+$(tput setaf 2)Initiating reboot to fastbootd.$(tput sgr0)
 "
 fastboot reboot fastboot
 
 fastboot $* getvar product 2>&1 | grep "^product: *QX1050"
 if [ $? -ne 0 ] ; then
-	echo "Checking for bengal device";
-	fastboot $* getvar product 2>&1 | grep "^product: *bengal"
-	if [ $? -ne 0 ] ; then
-		echo "$(tput setaf 1)Mismatched image and device$(tput sgr0)";
-		exit 1;
-	fi
+	echo "$(tput setaf 1)Mismatched image and device$(tput sgr0)";
+	exit 1;
 fi
 
 handle_error()


### PR DESCRIPTION
- Remove check for bengal since we ensure to be in fastbootd where the device is named QX1050.
- Add info that the screen will blank during flashing to ensure user.
- Adapt colors to only make success messages green, info in orange. Device mismatch and missing fastboot in red.

![grafik](https://user-images.githubusercontent.com/15074193/187999799-ec0df05b-b20f-4034-aa91-2d94ffb6abfd.png)
(With commented out flash commands)